### PR TITLE
meson.build: Add missing airscan-rand.c

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ sources = [
   'airscan-netif.c',
   'airscan-png.c',
   'airscan-pollable.c',
+  'airscan-rand.c',
   'airscan-trace.c',
   'airscan-uuid.c',
   'airscan-wsd.c',


### PR DESCRIPTION
The new file was added in commit 0184ec4 ("getrandom() replaced with
read from /dev/urandom (Debian 9.0 port)"), but was not added to
meson.build.  This causes linker errors when building with meson.