### PR TITLE
meson: Add airscan-discover target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,19 +34,21 @@ sources = [
 cc = meson.get_compiler('c')
 m_dep = cc.find_library('m', required : false)
 
+shared_deps = [
+  m_dep,
+  dependency('avahi-client'),
+  dependency('avahi-glib'),
+  dependency('libjpeg'),
+  dependency('libpng'),
+  dependency('libsoup-2.4'),
+  dependency('libxml-2.0'),
+]
+
 shared_library(
   meson.project_name(),
   sources,
   version: '1',
-  dependencies: [
-    m_dep,
-    dependency('avahi-client'),
-    dependency('avahi-glib'),
-    dependency('libjpeg'),
-    dependency('libpng'),
-    dependency('libsoup-2.4'),
-    dependency('libxml-2.0'),
-  ],
+  dependencies: shared_deps,
   link_args : [
     '-Wl,-z,nodelete',
     '-Wl,--version-script=' + join_paths(meson.current_source_dir(), 'airscan.sym')
@@ -56,5 +58,13 @@ shared_library(
   install_dir : 'lib/sane'
 )
 
+executable(
+  'airscan-discover',
+  sources + ['discover.c'],
+  dependencies: shared_deps,
+  install: true
+)
+
 install_man('sane-airscan.5')
+install_man('airscan-discover.1')
 install_data(['airscan.conf', 'dll.conf'], install_dir : 'etc/sane.d')


### PR DESCRIPTION
Build and install the airscan-discover binary added in commit 2652887
("Added airscan-discover, rewritten in C on a top of sane-airscan
infrastructure").  It builds the binary by re-linking all of the object
files instead of linking against a static lib.  The Makefile doesn't
pass any special flags, so this should produce the same end result.