### PR TITLE
Add AF_UNIX support to HTTP connections

### DIFF
--- a/airscan-conf.c
+++ b/airscan-conf.c
@@ -54,6 +54,8 @@ typedef struct {
     inifile_record      record;                 /* Record buffer */
 } inifile;
 
+static const char DEFAULT_SOCKET_DIR[] = "/var/run";
+
 /***** Functions *****/
 /* Open the .INI file
  */
@@ -757,6 +759,12 @@ conf_load_from_ini (inifile *ini)
                         conf_perror(rec, "usage: %s = fast | full | off",
                             rec->variable);
                     }
+                } else if (inifile_match_name(rec->variable, "socket_dir")) {
+                    mem_free((char*) conf.socket_dir);
+                    conf.socket_dir = conf_expand_path(rec->value);
+                    if (conf.socket_dir == NULL) {
+                        conf_perror(rec, "failed to expand socket_dir path");
+                    }
                 }
             } else if (inifile_match_name(rec->section, "debug")) {
                 if (inifile_match_name(rec->variable, "trace")) {
@@ -876,6 +884,7 @@ conf_load (void)
 
     /* Reset the configuration */
     conf = conf_init;
+    conf.socket_dir = str_dup(DEFAULT_SOCKET_DIR);
 
     /* Look to configuration path in environment */
     s = getenv(CONFIG_PATH_ENV);

--- a/airscan.conf
+++ b/airscan.conf
@@ -35,12 +35,18 @@
 # for this purpose:
 #   model = network     ; use network device name (default)
 #   model = hardware    ; use hardware model name
+#
+# socket_dir gives an optional path to a directory where local (UNIX) sockets
+# can be found.  If an eSCL device's URL is in the form unix://socket/eSCL/,
+# traffic will be sent through socket_dir/socket instead of TCP.  If not
+# specified, sockets will be searched for in /var/run.
 
 [options]
 #discovery = enable
 #model = network
 #protocol = auto
 #ws-discovery = fast
+#socket_dir = /var/run
 
 # Configuration of debug facilities
 #   trace = path        ; enables protocol trace and configures output

--- a/airscan.h
+++ b/airscan.h
@@ -826,6 +826,7 @@ typedef struct {
     bool        model_is_netname; /* Use network name instead of model */
     bool        proto_auto;       /* Auto protocol selection */
     WSDD_MODE   wsdd_mode;        /* WS-Discovery mode */
+    const char  *socket_dir;      /* Directory for AF_UNIX sockets */
 } conf_data;
 
 #define CONF_INIT {                     \
@@ -835,7 +836,8 @@ typedef struct {
         .discovery = true,              \
         .model_is_netname = true,       \
         .proto_auto = true,             \
-        .wsdd_mode = WSDD_FAST          \
+        .wsdd_mode = WSDD_FAST,         \
+        .socket_dir = NULL              \
     }
 
 extern conf_data conf;
@@ -856,7 +858,8 @@ conf_unload (void);
  * be passed by value
  */
 typedef struct {
-    char       text[64];
+    /* Holds sun_path from sockaddr_un plus a null byte. */
+    char       text[109];
 } ip_straddr;
 
 /* Format ip_straddr from IP address (struct in_addr or struct in6_addr)
@@ -866,7 +869,7 @@ ip_straddr
 ip_straddr_from_ip (int af, const void *addr);
 
 /* Format ip_straddr from struct sockaddr.
- * Both AF_INET and AF_INET6 are supported
+ * AF_INET, AF_INET6, and AF_UNIX are supported
  *
  * If `withzone' is true, zone suffix will be appended, when appropriate
  */
@@ -874,7 +877,7 @@ ip_straddr
 ip_straddr_from_sockaddr(const struct sockaddr *addr, bool withzone);
 
 /* Format ip_straddr from struct sockaddr.
- * Both AF_INET and AF_INET6 are supported
+ * AF_INET, AF_INET6, and AF_UNIX are supported
  *
  * Port will not be appended, if it matches provided default port
  * If `withzone' is true, zone suffix will be appended, when appropriate
@@ -1747,7 +1750,8 @@ http_query_foreach_response_header (const http_query *q,
 typedef enum {
     HTTP_SCHEME_UNSET = -1,
     HTTP_SCHEME_HTTP,
-    HTTP_SCHEME_HTTPS
+    HTTP_SCHEME_HTTPS,
+    HTTP_SCHEME_UNIX
 } HTTP_SCHEME;
 
 /* Some HTTP status codes

--- a/sane-airscan.5.md
+++ b/sane-airscan.5.md
@@ -68,6 +68,12 @@ devices it may differ. Discovering WSD URLs doing this way is much
 harder, because it is very difficult to guess TCP port and URL path,
 that in a case of eSCL.
 
+For eSCL devices, the URL can also use the unix:// scheme, such as
+unix://scanner.sock/eSCL.  The "host" from the URL is a file name that will be
+searched for in the directory specified by socket_dir (see below).  When
+connecting to the scanner, all traffic will be sent to the specified UNIX socket
+instead of a TCP connection.
+
 ## CONFIGURATION OPTIONS
 
 Miscellaneous options all goes to the ``[options]`` section. Currently
@@ -95,6 +101,11 @@ the following options are supported:
     ; This is also possible to disable automatic discovery
     ; of WSD devices. The default is "fast".
     ws-discovery = fast | full | off
+
+    ; Scanners that use the unix:// schema in their URL can only specify a
+    ; socket name (not a full path).  The name will be searched for in the
+    ; directory specified here. The default is /var/run.
+    socket_dir = /path/to/directory
 
 ## DEBUGGING
 

--- a/sane-airscan.5.md
+++ b/sane-airscan.5.md
@@ -54,6 +54,12 @@ device URL on a rights side, followed by protocol (eSCL or WSD). If protocol
 is omitted, eSCL is assumed.  You may also disable particular device by
 using the `disable` keyword instead of URL.
 
+In addition, you can manually configure a device by directly passing its URL in
+a device name without adding it to the configuration file.  This takes the
+format `protocol:Device Name:URL`.  The examples above could be written as
+`escl:Kyocera eSCL:http://192.168.1.102:9095/eSCL` and
+`wsd:Kyocera WSD:http://192.168.1.102:5358/WSDScanner`.
+
 To figure out URLs of available devices, the simplest way is to
 run a supplied `airscan-discover` tool on a computer connected with
 scanner to the same LAN segment. On success, this program will


### PR DESCRIPTION
Allow the URL for a device to be specified as unix://socket_name/... in
addition to the existing http:// URLs.  Also add a new socket_dir option
to the [options] section of airscan.conf.

When a unix:// URL is encountered, the sockdir_dir and socket_name
values are combined to form a full path to a local AF_UNIX socket.
Instead of attempting a TCP connection to the device, all HTTP requests
for that device are sent through the local socket.  The socket file
itself must be created by some external program that knows how to
communicate with the scanner, such as the Chrome OS ippusb_bridge that
forwards through an IPP-USB tunnel.

This also adds underscore to the list of accepted hostname characters in
http_parser.  Underscore is technically not legal in a hostname, but
it's extremely common in filenames and won't hurt parsing valid URLs.

Fixes alexpevzner/sane-airscan-unstable#11